### PR TITLE
Corrección de error OxxoPay

### DIFF
--- a/views/templates/hook/admin-order.tpl
+++ b/views/templates/hook/admin-order.tpl
@@ -45,7 +45,7 @@
 					<br>
 					<strong>{l s='Processed on:' mod='conektaprestashop'}</strong> {$processed_on|escape:'htmlall':'UTF-8'}
 					<br>
-					<strong>{l s='Mode:' mod='conektaprestashop'}</strong> <span style="font-weight: bold; color: {$color_mode|escape:'htmlall':'UTF-8'}};">{$txt_mode|escape:'htmlall':'UTF-8'}</span>
+					<strong>{l s='Mode:' mod='conektaprestashop'}</strong> <span style="font-weight: bold; color: {$color_mode|escape:'htmlall':'UTF-8'}};">{$txt_mode|unescape:"htmlall"}</span>
 				</p>
 			{else}
 				<span style="color: #CC0000;"><strong>{l s='Warning:' mod='conektaprestashop'}</strong></span> {l s='The customer paid using Conekta and an error occured (check details at the bottom of this page)' mod='conektaprestashop'}


### PR DESCRIPTION
#Se estaba haciendo un SELECT de _conekta_transactions_ sobre los registros que tuvieran el STATUS _paid_ lo cual regresaba **NULL** en el caso de las transacciones hechas por OxxoPay. 

Debajo se esta haciendo la siguiente validación:

```
if ($conekta_transaction_details['status'] === 'paid') { 
     //set color and message status
} 
else {
     //set color and message status
}
```
**UPDATE**
Principio DRY para mejora de la solución del issue (Gracias @fruizg0302)
Carácter -> (") no se visualizaban correctamente en el admin `(&amp quot;Live quot;&amp)` 
Usando lo siguiente:
```
{$articleTitle}
Germans use &quot;&Uuml;mlauts&quot; and pay in &euro;uro

{$articleTitle|unescape:"html"}
Germans use "&Uuml;mlauts" and pay in &euro;uro

{$articleTitle|unescape:"htmlall"}
Germans use "Ümlauts" and pay in €uro
```