### PR TITLE
Feature: Fix webhook

### DIFF
--- a/conektaprestashop.php
+++ b/conektaprestashop.php
@@ -1029,7 +1029,7 @@ class ConektaPrestashop extends PaymentModule
 
         $events = array(
             'events' => array(
-                'charge.paid'
+                'order.paid'
                 )
             );
 


### PR DESCRIPTION
**Why is this change neccesary?**
This change is a bug fix in order to get right event data as order contains reference_id and charge not 
**How does it address the issue?**
change webhook creating from charge.paid (version 1.0.0) to order.paid (version 2.0.0)
**What side effects does this change have?**
nothing, better user experience